### PR TITLE
Catch API 400 Error

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,7 +27,11 @@ async function renderData() {
 async function renderMiscData() {
     const response = await fetch(apiKey)
     const jsonData = await response.json()
-
+    if (response.status === 400) {
+        alert('Location not found. Please try again. \nCheck: \n - Spelling \n - Syntax (City, City State)')
+    } else {
+        console.log('nice!')
+    }
 
     if (jsonData.location.region == '') {
         cityState.innerText = jsonData.location.name + ', ' + jsonData.location.country


### PR DESCRIPTION
This is a test for practicing pull request best practices and processes!

**Description: **
This request addresses the case where the user entering a city name that doesn't exist in the API's record leads to a 400 Bad Request Error. The bad request stems from the user input being a number, a fake city, or simply a typo. With this fix, the error is caught and relayed to the user to try again, suggesting they check for typos.

**Benefits: **
- Enhances user experience by relaying to them how to proceed/fix the error
- Prevents application from appearing to "freeze" without any instruction on what went wrong

**Testing Done: **
 - Tested with numbers, misspelled cities, and blank inputs
 - Verified that when the 400 error occurs, the error handle triggers correctly